### PR TITLE
Memory leak

### DIFF
--- a/ScreenCapturer/ScreenCapturer.cs
+++ b/ScreenCapturer/ScreenCapturer.cs
@@ -154,8 +154,8 @@ namespace ScreenCapturerNS {
             Device?.Dispose();
             Adapter1?.Dispose();
             Factory1?.Dispose();
-            MakeScreenshot_LastAdapterIndexValue = -1;
-            MakeScreenshot_LastDisplayIndexValue = -1;
+            MakeScreenshot_LastAdapterIndexValue = 0;
+            MakeScreenshot_LastDisplayIndexValue = 0;
         }
 
     }

--- a/ScreenCapturer/ScreenCapturer.cs
+++ b/ScreenCapturer/ScreenCapturer.cs
@@ -33,8 +33,8 @@ namespace ScreenCapturerNS {
         private static OutputDuplication OutputDuplication;
         private static Bitmap Bitmap;
 
-        private static Int32 MakeScreenshot_LastDisplayIndexValue;
-        private static Int32 MakeScreenshot_LastAdapterIndexValue;
+        private static Int32 MakeScreenshot_LastDisplayIndexValue = 0;
+        private static Int32 MakeScreenshot_LastAdapterIndexValue = 0;
 
         static ScreenCapturer() {
             CaptureActive = false;


### PR DESCRIPTION
When first calling `StartCapturing(...)`, the constructor will initialize static variables
```csharp
InitializeStaticVariables(0, 0, true);
```
and later, in `DisposeVariables(...)`, set them to -1.
If you now call `StopCapturing()`, which results in variables being disposed, and call StartCapturing again, those checks
```csharp
Boolean displayIndexChanged = MakeScreenshot_LastDisplayIndexValue != displayIndex;
Boolean adapterIndexChanged = MakeScreenshot_LastAdapterIndexValue != adapterIndex;
```
will be true and you end up initializing variables twice, resulting in a memory leak.
